### PR TITLE
Contributer List has been updated

### DIFF
--- a/contributer-list.md
+++ b/contributer-list.md
@@ -6,12 +6,13 @@
 ```
 
 ### Contributors:
-* [Bill McClung](github.com/cfgauss)
-* [Joshua Hoffman](github.com/hoffmanjoshua)
-* [Kudakwashe Siziva](github.com/kaysiz)
-* [Jacky Hui](github.com/jackyhui96)
-* [Emily Martens](github.com/ekmartens)
-* [Viren Bhagat](github.com/virenb)
+* [Bill McClung](https://github.com/cfgauss)
+* [Joshua Hoffman](https://github.com/hoffmanjoshua)
+* [Kudakwashe Siziva](https://github.com/kaysiz)
+* [Jacky Hui](https://github.com/jackyhui96)
+* [Emily Martens](https://github.com/ekmartens)
+* [Viren Bhagat](https://github.com/virenb)
 * [Manuel Hölzl](https://github.com/manuel-hoelzl)
 * [Jesse Calton](https://github.com/jessecalton)
 * [Rannie Ollit](https://github.com/einnar82)
+* [Diego Gutierrez](https://github.com/daguttierrez)


### PR DESCRIPTION
## Description
The links were redirecting to a nonexistent url since they didn't have the `https://` at the beginning of the url.

- The `https://` has been added to the ones that were missing. 