### PR TITLE
Add two tone color background

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3,8 +3,6 @@ body {
 }
 .jumbotron {
 	background-color: #f29810;
-  padding: 0px;
-  margin-top: 0px;
 }
  .jumbotron p {
 	margin-top: 20%;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,5 +1,10 @@
-body, .jumbotron {
-	background-color: #FFB74D;
+body {
+  background-color: #f7a325;
+}
+.jumbotron {
+	background-color: #f29810;
+  padding: 0px;
+  margin-top: 0px;
 }
  .jumbotron p {
 	margin-top: 20%;
@@ -8,4 +13,4 @@ body, .jumbotron {
  a {
 	text-decoration: underline;
 	color: black;
-} 
+}


### PR DESCRIPTION
* Split the background of the page in half by setting the jumbotron background-color different from the body background-color.
* The color is currently set to a darker orange for the jumbotron background color and a lighter orange for the body background color.
* The colors can be changed to look better.