### PR TITLE
Fixed jumbot bg color animation setted the same as main

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -16,7 +16,7 @@ main {
 
 .jumbotron {
 background-color: #f29810;
-animation: jumbotron-background-animation 30s linear infinite;
+animation: body-background-animation 30s linear infinite;
 }
 .jumbotron p {
   margin-top: 20%;
@@ -136,33 +136,6 @@ p {
 
 
 @keyframes body-background-animation {
-	0% {
-		background-color: #f7a325;
-	}
-	20% {
-		background-color: #f7252f;
-	}
-	35% {
-		background-color: #f7252f;
-	}
-	36% {
-		background-color: #3d25f7;
-	}
-	64% {
-		background-color: #3d25f7;
-	}
-	65% {
-		background-color: #f7252f;
-	}
-	80% {
-		background-color: #f7252f;
-	}
-	100% {
-		background-color: #f7a325;
-	}
-}
-
-@keyframes jumbotron-background-animation {
 	0% {
 		background-color: #f7a325;
 	}

--- a/css/styles.css
+++ b/css/styles.css
@@ -164,15 +164,27 @@ p {
 
 @keyframes jumbotron-background-animation {
 	0% {
-		background-color: #f29810;
+		background-color: #f7a325;
+	}
+	20% {
+		background-color: #f7252f;
 	}
 	35% {
-		background-color: #72f210;
+		background-color: #f7252f;
+	}
+	36% {
+		background-color: #3d25f7;
+	}
+	64% {
+		background-color: #3d25f7;
 	}
 	65% {
-		background-color: #72f210;
+		background-color: #f7252f;
+	}
+	80% {
+		background-color: #f7252f;
 	}
 	100% {
-		background-color: #f29810;
+		background-color: #f7a325;
 	}
 }


### PR DESCRIPTION
**Set jumbot background color the same as main background color**

TYPE: 
- [x] Small bug fix (non-breaking change which fixes an issue)

#### Description of the Change Being Made.
Set jumpbot and main background color animation the same, so there is no difference not and it looks much more better

#### Issue Number
None

#### Tests/Checks
No tested needed

#### New Dependencies
No



