### PR TITLE
Move pumpkin to the top

### DIFF
--- a/css/pumpkin.css
+++ b/css/pumpkin.css
@@ -5,7 +5,7 @@ body{
   .image{
     position: absolute;
     left: 50%;
-    top: 80%;
+    top: 25%;
     margin-left: -150px;
     margin-top: -120px;
     width: 300px;


### PR DESCRIPTION
Moves pumpkin to the top of the page so that the text is readable and not obstructed by the pumpkin.